### PR TITLE
Fix deformatter to properly handle all cases

### DIFF
--- a/src/TextFormatter.js
+++ b/src/TextFormatter.js
@@ -5,7 +5,7 @@ class TextFormatter {
      * @type {RegExp}
      * @private
      */
-    static deformatRegex = /(\$[wnoitsgz><]|\$[lh]\[.+\]|\$[lh]|\$[0-9a-f]{1,3})/gi;
+    static deformatRegex = /\$((\$)|[0-9a-f]{2,3}|[lh]\[.*?\]|.)/gi;
 
     /**
      * Regex to match all the color formatting codes
@@ -27,7 +27,7 @@ class TextFormatter {
      * @returns {string}
      */
     static deformat(input) {
-        return input.replace(this.deformatRegex, "");
+        return input.replace(this.deformatRegex, "$2");
     }
 
     /**


### PR DESCRIPTION
The `deformatRegex` has been replaced with a smaller and more performant (around 20% faster) solution, created by Solux and me.

It fixes two issues:
- Fix the deformatter to work on escaped dollars
- Fix the deformatter to work on all characters preceding the dollar

A breakdown of the changes:
- `[lh]\[.+\]` has been changed to `[lh]\[.*?\]`, because Trackmania also accepts zero length links (`+` to `*`), and stops after the first bracket with the `?` lazy modifier
- `[wnoitsgz><]|[lh]` has been changed to `(\$|.)`, as in Trackmania, any character after a dollar, unless it is another dollar, will be removed.
This parity issue is fixed by matching two subsequent dollar signs, and putting the second one in a separate capture group. This capture group is used in the `.replace()` function to keep a single dollar of any match with double dollar signs, otherwise, it will return nothing.
- `[0-9a-f]{1,3}` has been changed to `[0-9a-f]{2,3}`, as with the solution above, every color format character is already matched, thus only two or three subsequent color format characters must be matched.
- The regex has also been cleaned up by factoring out the dollar sign since every format begins with a dollar sign.

The resulting regex is `/\$((\$)|[0-9a-f]{2,3}|[lh]\[.*?\]|.)/gi`, replacing matches with the contents of the second capture group.