### PR TITLE
Fix formatAnsi not working

### DIFF
--- a/src/TextFormatter.js
+++ b/src/TextFormatter.js
@@ -5,7 +5,7 @@ class TextFormatter {
      * @type {RegExp}
      * @private
      */
-    static deformatRegex = /\$((\$)|[0-9a-f]{2,3}|[lh]\[.*?\]|.)/gi;
+    static deformatRegex = /(\$(?:(\$)|[0-9a-f]{2,3}|[lh]\[.*?\]|.))/gi;
 
     /**
      * Regex to match all the color formatting codes
@@ -38,7 +38,7 @@ class TextFormatter {
     static formatAnsi(input) {
         let output = "";
 
-        let split = input.split(this.deformatRegex);
+        let split = input.split(this.deformatRegex).filter((i) => i && i != "$");
 
         split.forEach((part) => {
             output += this.colorToAnsi(part);


### PR DESCRIPTION
Fixes the following:
- Fix deformatRegex by adding non-capture groups for the split function

To fix the issue above, the regex has been updated to put the first group into a non-capture group, and grouping the whole regex separately for the split function to work properly. A filter has been added to the `split` variable inside `formatAnsi` to remove any undefined returns (`(i) => i`) and fix escaped dollars being split (`(i) => i != "$"`).
The latter one is caused because `(\$)` in the regex is a capture group. If it wasn't, this wouldn't be necessary, however the deformatter would cease to work.