### PR TITLE
Fix negative times not formatting properly

### DIFF
--- a/src/Time.js
+++ b/src/Time.js
@@ -21,6 +21,9 @@ class Time {
         if (this.time == null) {
             output = "-:--.---";
         } else {
+            if (Math.sign(this.time) == -1) output += "-";
+            this.time = Math.abs(this.time);
+            
             let ms = this.time % 1000,
                 s = Math.floor(this.time / 1000) % 60,
                 m = Math.floor(this.time / 60000) % 60,

--- a/test/TimeFormat.test.js
+++ b/test/TimeFormat.test.js
@@ -4,6 +4,7 @@ const assert = require('assert'),
 
 describe("Time Formatting", function(){
     it("should convert time to string", function(){
+        assert.equal("-0:01.337", tmessentials.Time.fromMilliseconds(-1337).toTmString());
         assert.equal("0:01.337", tmessentials.Time.fromMilliseconds(1337).toTmString());
         assert.equal("0:13.370", tmessentials.Time.fromSeconds(13.370).toTmString());
         assert.equal("13:37.00", tmessentials.Time.fromMinutes(13.37).toTmString(true));


### PR DESCRIPTION
Negative times would not display properly. I have fixed it by adding a negative sign to the output if needed and then replacing the input with its absolute value.

`Time.fromMilliseconds(-1337).toTmString();` would display `-1:-2.NaN`, while the expected output would be `-0:01.337`.